### PR TITLE
Add pre-onboarding reading list

### DIFF
--- a/docs/reading_list.md
+++ b/docs/reading_list.md
@@ -29,7 +29,7 @@ This is a short reading list that we send out to new engineers before their firs
   reference that all team members should be familiar with.
 
   As an example of how we put our engineering values into practice, **code review** is one of the main ways that developers interact with each other during
-  their work and [reviewing with care and humanity](https://hyp.is/-Q6K2gwfEe2htfvft46lfg/web.hypothes.is/jobs/engineering-values/) is specifically called
+  their work and [reviewing with care and humanity](https://hyp.is/-Q6K2gwfEe2htfvft46lfg/web.hypothes.is/jobs/engineering-values/) is called
   out in our engineering values. Code reviews should be kind, patient, friendly and helpful, an uplifting experience that helps to foster our team culture.
   For some reading on code review techniques see:
 


### PR DESCRIPTION
Fixes https://github.com/hypothesis/onboarding/issues/19.

This is a reading list that a new engineer's manager will email to new engineers _before_ they join Hypothesis.

This is just a "you might be interested in this" not a "required reading" so we don't keep track of whether or not the engineer actually reads the items (and each item will come up again to read later in the onboarding process).