### PR TITLE
Add dummy issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_pre_onboarding.md
+++ b/.github/ISSUE_TEMPLATE/01_pre_onboarding.md
@@ -1,0 +1,8 @@
+---
+name: 01. Pre-onboarding
+about: New engineer pre-onboarding tasks
+title: Pre-onboarding <USERNAME>
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/02_introduction.md
+++ b/.github/ISSUE_TEMPLATE/02_introduction.md
@@ -1,0 +1,8 @@
+---
+name: 02. Introduction
+about: New engineer introductory tasks
+title: <USERNAME> Introduction
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/03_development_environment.md
+++ b/.github/ISSUE_TEMPLATE/03_development_environment.md
@@ -1,0 +1,8 @@
+---
+name: 03. Development Environment
+about: New engineer development environment setup
+title: <USERNAME> Development Environment Setup
+labels: ''
+assignees: ''
+
+---

--- a/.github/ISSUE_TEMPLATE/04_first_pr.md
+++ b/.github/ISSUE_TEMPLATE/04_first_pr.md
@@ -1,0 +1,9 @@
+---
+name: 04. First PR
+about: New engineer first PR
+title: <USERNAME> First PR
+labels: ''
+assignees: ''
+
+---
+

--- a/.github/ISSUE_TEMPLATE/05_dependabot.md
+++ b/.github/ISSUE_TEMPLATE/05_dependabot.md
@@ -1,0 +1,8 @@
+---
+name: 05. Dependabot PRs
+about: New engineer first Dependabot PRs
+title: <USERNAME> First Dependabot PRs
+labels: ''
+assignees: ''
+
+---


### PR DESCRIPTION
Add dummy issue templates

There's no actual content in these issue templates yet, this is just so that I can test the process of copying a board and populating it from several separate issue templates.
