### PR TITLE
Add pre-onboarding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_pre_onboarding.md
+++ b/.github/ISSUE_TEMPLATE/01_pre_onboarding.md
@@ -1,0 +1,10 @@
+---
+name: 01. Pre-onboarding
+about: Tasks to be done before a new engineer's first day
+title: <@username> Pre-onboarding
+labels: ''
+assignees: ''
+
+---
+
+- [ ] **Manager**: send the engineer a copy of the [Pre-onboarding Reading List](https://github.com/hypothesis/onboarding/blob/main/docs/reading_list.md)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/onboarding/issues/2.

GitHub will offer this template as an option when you create a new issue in the onboarding repo. There is also an option to create an issue without using the template. Further pull requests will add more templates to choose from when creating issues in this repo.

There's a suggested order to the issues to be created for a new engineer's onboarding board, hence why the issue templates are going to be numbered (which means that GitHub will show them in the right order when you go to create an issue).