### PR TITLE
Add "Introduction" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_introduction.md
+++ b/.github/ISSUE_TEMPLATE/02_introduction.md
@@ -1,0 +1,15 @@
+---
+name: 02. Introduction
+about: Introductory tasks for a new engineer
+title: "<@username> Introduction"
+labels: ''
+assignees: ''
+
+---
+
+- [ ] **Manager**: **schedule a product walkthrough** for the engineer with someone from product or support
+  - [ ] **Engineer**: check off this item once you've had the product walkthrough
+- [ ] **Manager**: **assign a buddy** for the engineer's onboarding
+  - [ ] **Manager**: schedule a 1:1 between the engineer and their buddy
+  - [ ] **Engineer**: check off this item once you've had your first 1:1 with your buddy
+- [ ] **Engineer**: (re-)read the [Hypothesis Company Principles](https://web.hypothes.is/principles/)


### PR DESCRIPTION
Fixes https://github.com/hypothesis/onboarding/issues/1.

This adds the second issue template for use on new engineer onboarding boards, which is a few introductory tasks for the engineer and their manager to complete.

The issue is also supposed to contain a paragraph or two explaining the onboarding process to the new engineer and letting them know what to expect from their first few months at Hypothesis. Or maybe that text will end up living somewhere else (e.g. in `README.md`). Anyway, I can't really write such a paragraph right now because I haven't finished creating the onboarding process yet so there's a separate issue for that: https://github.com/hypothesis/onboarding/issues/33

See https://github.com/hypothesis/onboarding/issues/1 for context.