### PR TITLE
Add development environment issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/03_development_environment.md
+++ b/.github/ISSUE_TEMPLATE/03_development_environment.md
@@ -1,0 +1,14 @@
+---
+name: 03. Development environment set up
+about: Tasks for a new engineer to set up their development environment
+title: <@username> Development Environment Set Up
+labels: ''
+assignees: ''
+
+---
+
+- [ ] **Engineer**: read our [high-level architecture overview](/docs/architecture.md)
+- [ ] **Engineer**: set up your local development environment and get everything working locally.
+      Follow [our guide](/docs/DEVELOPING.md)
+- [ ] **Buddy**: schedule a call with the engineer to check-in and answer any questions they have
+  - [ ] **Engineer**: check off this item once you've had the check-in with your buddy

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,7 @@
+Hypothesis Architecture Overview
+================================
+
+This file is intended to one day contain a basic high-level overview of
+Hypothesis's system architecture (see https://github.com/hypothesis/onboarding/issues/16).
+For now [Nick's H Architecture Talk](https://docs.google.com/document/d/1saDTLAniQiwV3KlUE7imo1ZP2BVSVEOQm_yfbKbCKn4/)
+from 2017 is the best we have.


### PR DESCRIPTION
Add an issue template for new engineers to learn about the Hypothesis system architecture and set up their local development environment.

Fixes https://github.com/hypothesis/onboarding/issues/3

There's a [separate issue](https://github.com/hypothesis/onboarding/issues/16) to update the architecture diagram.

There's also a [separate issue](https://github.com/hypothesis/onboarding/issues/18) to write some docs about the development environment and add a task to this issue template to read them