### PR TITLE
Document how we decide to add a new dependency

### DIFF
--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,63 @@
+# How do we decide when to add a new technology?
+
+How do we decide when to add new tech to our stack,
+like a new Python or JavaScript package,
+or a new database or alerting system?
+ 
+Adding a dependency can save us significant development and
+maintenance time: we don't want to implement things that are already
+well-solved by the ecosystem. But each dependency is also one more thing that
+Hypothesis developers need to learn, and we'll always have to keep it up to
+date. 
+[New problems don't typically require new technology or architectures.](https://hyp.is/-LfAyByIEe2Ws3_8PLlVpA/web.hypothes.is/jobs/engineering-values/)
+
+[We want a small number of high quality, well-maintained, mature technologies](https://boringtechnology.club/)
+that are easy to learn and keep up to date, not a large number of poorly
+maintained dependencies that are hard to use and frequently cause problems.
+
+When proposing to add a new dependency to a project you should:
+
+* Discuss the new dependency with other developers.
+
+  Always ask how you'd solve your immediate problem without adding anything new.
+  Write down exactly what about the current stack makes solving the problem prohibitively expensive and difficult.
+  Does it outweigh the costs of adding the new technology?
+
+* Send a pull request (PR) that adds the new dependency, explaining in the PR description the motivation for adding the new dependency
+
+## Guidelines
+
+Some guidelines for deciding whether to add a new technology:
+
+### Consistency speeds everyone up
+
+There's are many good reasons to use the same stack to solve the same problems in different projects, here's just a few:
+
+* **Cognitive load reduction**: Hypothesis developers only need to learn one thing, not multiple.
+* **Maintenance load reduction**:  when the dependency releases a new version you only need to read the
+  changelog once to update all our projects. No need to deal with all the breaking changes from new releases of multiple projects when one
+  would have sufficed.
+* **Operational load reduction**: deployment, monitoring, scaling, backups. Learning how to operate a stack effectively is hard.
+
+### Adding a new dependency might be a good idea if...
+
+* **We already use the dependency** in other Hypothesis projects.
+* It **solves a significant problem**, making carrying this dependency worth the cost.
+* It's **widely used**. This is a sign of maturity, could imply better support, and new developers are more likely to be familiar with the project.
+* It's **actively maintained**, with regular releases and good changelogs.
+* It has **good documentation**, making it easier to learn and use.  
+ * Python packages should **document what versions of Python they support**, this makes upgrading our Python version easier.
+* It **works with our existing technology stack** (e.g. supports our web framework or build tooling),
+  and is easy to integrate into our projects.
+* It will be **easy to remove** if we change our minds.
+
+### Adding a new dependency might **not** be a good idea if...
+
+* **We already use another dependency** to solve the same problem in this or another project.
+* **It solves only a trivial problem**.
+  Would it be cheaper to write our own code and maintain that?
+* It would mean **using a big, complex technology to solve a small, simple problem**.
+  The cost of Hypothesis developers having to learn the technology might
+  outweigh the benefits.
+* It would introduce **architectural complexity** (for example adding
+  a message queue server). This greatly increases the cost.


### PR DESCRIPTION
[Preview the new docs rendered to HTML](https://github.com/hypothesis/onboarding/blob/dependencies/docs/dependencies.md)

Yak shaving: one of the tasks that's going to go into the onboarding process for new developers is to handle their first batch of Dependabot PRs. In a separate PR I'm going to be updating our [documentation on why and how we use Dependabot](https://github.com/hypothesis/onboarding/pull/40) (how to handle a Dependabot PR) and moving it into this repo. But the how-and-why of using Dependabot is entangled with our approach to deciding when and when not to add new dependencies to our projects:

* If we have a small number of high quality, well-maintained dependencies and use a consistent set of dependencies across projects then we'll have an easier time with Dependabot PRs, among other advantages
* If we have a large number of poor quality, poorly maintained dependencies and frequently use multiple different dependencies to solve the same problems where one would have sufficed then Dependabot PRs will be an ongoing nightmare, among other disadvantages

We have some [existing documentation on Stack Overflow](https://stackoverflow.com/c/hypothesis/questions/469) about how to decide whether to add a new Python dependency. That Stack Overflow post will be replaced with a link to this PR's file once this PR is merged. I've read over the SO post closely and integrated much of it into this PR, but I'm trying to do something slightly different with this new documentation

### What I'm trying to do with these guidelines

The onboarding repo is going to end up containing guidelines for several things: how to write a good PR; crafting good commits; how to do a good code review; how to decide whether to add a new dependency; how to handle a Dependabot PR; and a few more. These guidelines are supposed to follow on from our engineering values and describe how we apply those values to specific practices. In conversations with @darylhedley we've talked about the "5-10 rules" that you need to know to contribute to Hypothesis.

I want the guidelines to refer to our engineering values, indicate how our practices apply our engineering values. In the case of deciding when to add dependencies I think "don't be afraid to be boring: new problems don't typically require new technology, nor new architectures" is relevant, as well as "consistency speeds everyone up", 

Whenever the guidelines advise you to do something they also explain _why_, while remaining as concise as possible. For example in this PR's guidelines I haven't just stated that being widely used is a sign of a good dependency. I've also explained that widely used projects have large developer and user communities that provide support, are likely to be familiar to new developers we hire, and are less likely to become unmaintained.

I want these guidelines to apply to the whole team whenever possible. I can deliver more value by documenting things for everyone rather than just for the backend team.

I want each guideline to be concise and clearly structured: at most a handful of introductory paragraphs followed by several bullet points. No essays or wandering discussions. The guideline in this PR is pushing at the limits of how long I want these to get.

While respecting that many decisions are subjective and require judgement, I want the guidelines to give simple, concrete advice on how we want people to do things. I think that's what the team needs in order to grow sustainably. I want to avoid guidelines that have too much of the flavour of "Everything's complicated, here's various discussion, use your own judgement", because I don't think those would be of much practical use to us. The aim is to put in place foundations that're going to enable us to scale the team smoothly.