### PR TITLE
Add docs about deployment

### DIFF
--- a/docs/merging.md
+++ b/docs/merging.md
@@ -1,0 +1,34 @@
+Merging a Pull Request
+======================
+
+Your code isn't really working until it's working in production. Developers at
+Hypothesis are empowered (and required) to merge their own pull requests (PRs)
+and verify that their changes work once deployed or released.
+
+When you merge changes into a project, you're not done yet. Your changes need
+to be deployed or released:
+
+* **PRs merged into web apps** are automatically deployed to a QA environment
+  where it is your responsibility to test them and deploy them to production
+  without delay. See [our deploying docs](https://github.com/hypothesis/playbook/blob/main/docs/deploying.md)
+  for details. Leaving undeployed commits on QA can slow down the next
+  developer — who might be trying to deploy urgent changes — as their commits
+  can't be deployed without also deploying yours.
+* After **merging PRs into other projects**, you may need to release a version
+  of that project. Instructions can be found in each project's `README`.
+
+We ship working code incrementally ("continuous deployment") instead of trying
+to release months of work all at once. You'll release or deploy a project right
+after merging each PR or small batch of PRs. Deploying a single small PR
+individually is typical. We do it this way because:
+
+* We want to [get features and fixes to users fast](https://hyp.is/I3ILSBf3Ee2PtgdQobKl1A/web.hypothes.is/jobs/engineering-values/)
+  and avoid giant leaps in the wrong direction.
+
+* The best way to limit the risk of deploying code is to do it as often as
+  possible. We know that our deployment mechanism is quick and safe because we
+  use it many times a day.
+
+* [The most plausible answer to "what went wrong" is usually "the last thing we changed."](https://blog.skyliner.io/ship-small-diffs-741308bec0d1)
+  When a deployment breaks something it's easier to pinpoint the problem if the
+  diff you just deployed was a handful of lines rather than thousands.


### PR DESCRIPTION
[HTML view of the new docs](https://github.com/hypothesis/onboarding/blob/deployment/docs/merging.md).

<https://github.com/hypothesis/onboarding/pull/38/> adds an issue template for a new developer to make their first PR, get it reviewed, and deploy it.

I want to keep the issue template itself short and have it link out to other docs. For example it links to separate documentation about our pull request guidelines.

One of the tasks in the issue template is to deploy your PR once its been approved. Here I want to say something about continuous deployment: why do we ask developers to deploy their own PRs, and to deploy each PR individually as soon as it's merged (instead of releasing six months of work all at once)? How does our approach to deployments put our engineering values into practice?

But I don't want to put that in the issue template itself, so I need a separate document to link to. This PR adds that document.

### These docs versus the ones in the playbook

There's an awkward conflict between these docs and [the deployment docs in the playbook](https://github.com/hypothesis/playbook/blob/main/docs/deploying.md). This PR sticks to the philosophy/why of our approach to deployment and the playbook docs cover the how. In this PR I've resolved it by having these docs end with a link to the playbook ones. I hope that's at least enough to enable a review of the text in this PR? But longer term (or possibly before we merge this) I think we should merge the two docs.

Even more awkwardly Ian is currently working on a GitHub Actions-based deployment mechanism that will be completely replacing the Jenkins one and obviously the Jenkins-based docs will need to be replaced as part of that.

Options:

1. Put the new GitHub Actions-based deployment docs at the bottom of this `onboarding/docs/deploying.md` file
2. Put the new GitHub Actions-based deployment docs in the `playbook/docs/deploying.md` file in (in place of the current Jenkins-based docs) and move the contents of this `onboarding/docs/deploying.md` file to the top `playbook/docs/deploying.md` (and update the link in the issue template to `playbook/docs/deploying.md`)
3. Put the new GitHub Actions-based deployment docs in the `playbook/docs/deploying.md` file in (in place of the current Jenkins-based docs) and leave this `onboarding/docs/deploying.md` file as it is, with some text followed by a link to `playbook/docs/deploying.md`

Option 1 would be my preference. Particularly because the `onboarding` repo is intended to be public one day and if we have a really good GitHub Actions-based deployment mechanism and great docs for that it'll be good for potential new contributors to be able to see that.