### PR TITLE
Add "Deploy your first batch of Dependabot PRs" issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/05_dependabot.md
+++ b/.github/ISSUE_TEMPLATE/05_dependabot.md
@@ -1,0 +1,15 @@
+---
+name: 05. Handling Dependabot pull requests
+about: Tasks for a new engineer to handle their first batch of Dependabot pull requests
+title: <@username>: Deploy your first batch of Dependabot PRs
+labels: ''
+assignees: ''
+
+---
+
+We receive regular automated pull requests from Dependabot. Each developer is responsible for reviewing and deploying their fair share of dependency upgrades. In this phase of your onboarding you'll start reviewing Dependabot PRs, merging them, and deploying them to production.
+
+- [ ] **Engineer**: read our [docs about handling Dependabot PRs](https://github.com/hypothesis/onboarding/blob/main/docs/dependabot.md).
+- [ ] **Engineer**: review and deploy your first batch of Dependabot PRs.
+
+  You can use the [`dependencies` label on GitHub](https://github.com/pulls?q=org%3Ahypothesis+is%3Aopen+is%3Apr+sort%3Acreated+label%3Adependencies+) to find open Dependabot PRs. Your buddy can help you identify some good ones to tackle first.


### PR DESCRIPTION
[Preview as HTML](https://github.com/hypothesis/onboarding/blob/add-dependabot-issue-template/.github/ISSUE_TEMPLATE/05_dependabot.md)

After making your first PR (and getting it reviewed and deploying it) the next onboarding issue is going to be to review and deploy your first batch of Dependabot PRs.

There's not a whole lot to do here because we've already done the bulk of the work in the [doc about why we use Dependabot and how to handle a Dependabot PR](https://github.com/hypothesis/onboarding/blob/main/docs/dependabot.md). The actual issue template doesn't have to do much more than link to this.