### PR TITLE
Add "Writing Commits & PRs" guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_first_pr.md
+++ b/.github/ISSUE_TEMPLATE/04_first_pr.md
@@ -41,6 +41,6 @@ In this phase of your onboarding you'll start making your first pull requests (P
 
   If your PR was to a web app you need to test on QA and deploy to production. If your PR is to another project you may need to release a new version of that project. See our [docs about merging PRs](https://github.com/hypothesis/onboarding/blob/main/docs/merging.md) for details.
 
-[1]: https://stackoverflow.com/c/hypothesis/questions/385/386
-
 You can close this issue once you've deployed at least one of your PRs to production. Now that you now know how to write PRs and deploy them you can work with your buddy to identify more issues to fix.
+
+[1]: https://github.com/hypothesis/onboarding/blob/main/docs/commits_and_prs.md

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -50,14 +50,6 @@ because it works well with Git and GitHub which treat the first line as a title
 and use it throughout their interfaces.
 Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) because it's short and clear.[^1]
 
-#### What should go in PR titles and bodies?
-
-For single-commit PRs GitHub pre-fills the title and body from the commit
-message. You might add some more details to the PR body yourself: screenshots,
-testing instructions, review notes. Multi-commit PR titles can follow the same
-style as for single commits, the PR title and body can document the PR as a
-whole while commit messages can add detail to individual commits.
-
 [^1]: Using the imperative mood means writing your commit title as if giving
   the code a command to change itself, for example
   <b>Refactor foo service for readability</b> (not <q>Foo service refactoring</q>) or
@@ -66,6 +58,14 @@ whole while commit messages can add detail to individual commits.
   <b>Revert <code><title_of_earlier_commit></code>"</b> (from `git revert`),
   <b>Merge pull request #2371</b> (from GitHub's merge button),
   <b>Bump marshmallow from 3.17.1 to 3.18.0a</b> (from Dependabot).
+
+#### What should go in PR titles and bodies?
+
+For single-commit PRs GitHub pre-fills the title and body from the commit
+message. You might add some more details to the PR body yourself: screenshots,
+testing instructions, review notes. Multi-commit PR titles and bodies can
+follow the same style as commit messages but should document the PR as a whole
+and let the commit messages detail the individual commits.
 
 Respond collaboratively to reviews
 ----------------------------------

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -35,11 +35,6 @@ write to explain your change to the whole team, not just the individual who'll r
 Enable future code archaeology: make it possible to understand and revisit your
 change months or years from now.
 
-As with breaking changes into atomic commits and small PRs, writing good commit
-and PR messages improves the quality of your work: it's a self-review that helps
-you clearly organize your thoughts and understand what you've done and whether
-it really solves the problem.
-
 #### What should go in commit and PR messages?
 
 A commit's diff shows **how** the change was made: what lines of code were

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -60,8 +60,8 @@ Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) because
 For single-commit PRs GitHub pre-fills the title and body from the commit
 message. You might add some more details yourself: screenshots, testing
 instructions, review notes. Multi-commit PR titles can follow the same style as
-for single commits[^2], the PR title and body can document the PR as a whole
-while commit messages can add detail to individual commits.
+for single commits, the PR title and body can document the PR as a whole while
+commit messages can add detail to individual commits.
 
 [^1]: Using the imperative mood means writing your commit title as if giving
   the code a command to change itself, for example
@@ -71,19 +71,6 @@ while commit messages can add detail to individual commits.
   <b>Revert <code><title_of_earlier_commit></code>"</b> (from `git revert`),
   <b>Merge pull request #2371</b> (from GitHub's merge button),
   <b>Bump marshmallow from 3.17.1 to 3.18.0a</b> (from Dependabot).
-
-[^2]: GitHub pre-fills multi-commit PR titles from the **branch name**,
-  capitalising the first letter and replacing dashes with spaces,
-  so a good style is to name branches like PR titles:
-  summarize the intent in imperative mood in less than 50 chars, but in
-  lower-case and with dashes for spaces:
-  `refactor-foo-service-for-readability`,
-  `fix-crash-when-creating-user-with-long-name`.
-  This makes for descriptive branch names that aren't too long or short and
-  that match their PR titles.
-  It doesn't require you to be clairvoyant about knowing what the PR title will
-  be before you create the local branch: you can always rename the branch
-  before pushing with `git branch --move <new_name>`.
 
 Respond collaboratively to reviews
 ----------------------------------

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -24,13 +24,6 @@ Make commits atomic: CI should be passing after each commit to make tools like
 `git revert` and `git bisect` effective and history easier to navigate (no
 "fix", "typo" and "test" commits).
 
-<details><summary><b>When should you include more than one commit in a PR?</b></summary>
-If a few closely related commits would be easier to review and deploy together
-then you might want to include them in the same PR.
-If commits can be decoupled into independently-reviewable, smaller PRs then it
-might be better to split them up.
-</details>
-
 Write helpful commit messages, PR titles, and PR bodies
 -------------------------------------------------------
 

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -1,0 +1,105 @@
+Writing Commits and Pull Requests
+=================================
+
+Small, atomic commits and pull requests (PRs) with helpful commit messages,
+PR titles and PR bodies are great for collaboration and key to a maintainable
+project. Tools like [`git rebase`](https://docs.github.com/en/get-started/using-git/using-git-rebase-on-the-command-line)
+can help you to rewrite commits and split up branches to tell a clean and coherent story.
+
+Make small PRs and atomic commits
+---------------------------------
+
+A good guide is that each PR should do "one thing": a single logical change.
+Needing "and" in your PR title might be a sign that you should split it up. If
+you discover a bug while adding a new feature, send a separate PR to
+fix the bug. If code doesn't follow current conventions do a refactoring commit
+first then a separate commit to make your functional change. We like small PRs
+because:
+
+* They're necessary for [continuous deployment](merging.md): you can't deploy a small diff without first merging a small PR.
+* They get faster, better reviews: it takes less time and context-switching to review a small, focused PR.
+* They improve the quality of your work by encouraging clearly organized thinking, modular code, and purity of purpose.
+
+Make commits atomic: CI should be passing after each commit to enable tools
+like `git revert` and `git bisect` to be used effectively and to make history
+easier to browse and search by avoiding "fix", "typo" and "test" commits. Run
+`make sure` locally to make sure that CI will pass.
+
+<details><summary><b>When should you include more than one commit in a PR?</b></summary>
+If a few closely related commits would be easier to review and deploy together
+then you might want to include them in the same PR.
+If commits can be decoupled into independently-reviewable, smaller PRs then it
+might be better to split them up.
+</details>
+
+Write helpful commit messages, PR titles, and PR bodies
+-------------------------------------------------------
+
+Good commit messages make tools like `git blame`, `git revert` and `git log`
+come to life. Good titles and bodies make PRs easier to review by explaining
+your intent, reasoning and context rather than making your reviewer figure it
+out.
+
+[Every line of code is always documented](https://mislav.net/2014/02/hidden-documentation/):
+write to explain your change to the whole team, not just the individual who'll review it.
+Enable future code archaeology: make it possible to understand and revisit your
+change months or years from now.
+
+As with breaking changes into atomic commits and small PRs, writing good commit
+and PR messages improves the quality of your work: it's a self-review that helps
+you clearly organize your thoughts and understand what you've done and whether
+it really solves the problem.
+
+#### What should go in commit and PR messages?
+
+A commit's diff shows **how** the change was made: what lines of code were
+changed. It's up to the commit message to document **what you intended** the
+commit to achieve, **why** you're making this change, and any **context**
+or background knowledge necessary to understand the change.
+[My favourite Git commit](https://dhwthompson.com/2019/my-favourite-git-commit) (written by a former Hypothesis developer)
+and [Telling stories through your commits](https://blog.mocoso.co.uk/talks/2015/01/12/telling-stories-through-your-commits/)
+have some great tips.
+
+The first line of a commit should summarize the intent in less than 50 chars
+because it works well with Git and GitHub which treat the first line as a title
+and use it throughout their interfaces.
+Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) because it's short and clear.[^1]
+
+For single-commit PRs GitHub pre-fills the title and body from the commit
+message. You might add some more details yourself: screenshots, testing
+instructions, review notes. Multi-commit PR titles can follow the same style as
+for single commits[^2], the PR title and body can document the PR as a whole
+while commit messages can add detail to individual commits.
+
+[^1]: Using the imperative mood means writing your commit title as if giving
+  the code a command to change itself, for example
+  <b>Refactor foo service for readability</b> (not <q>Foo service refactoring</q>) or
+  <b>Fix crash when creating user with long name</b> (not <q>Fixed...</q> or <q>This fixes...</q> etc).
+  This matches the style of automated commit messages:
+  <b>Revert <code><title_of_earlier_commit></code>"</b> (from `git revert`),
+  <b>Merge pull request #2371</b> (from GitHub's merge button),
+  <b>Bump marshmallow from 3.17.1 to 3.18.0a</b> (from Dependabot).
+
+[^2]: GitHub pre-fills multi-commit PR titles from the **branch name**,
+  capitalising the first letter and replacing dashes with spaces,
+  so a good style is to name branches like PR titles:
+  summarize the intent in imperative mood in less than 50 chars, but in
+  lower-case and with dashes for spaces:
+  `refactor-foo-service-for-readability`,
+  `fix-crash-when-creating-user-with-long-name`.
+  This makes for descriptive branch names that aren't too long or short and
+  that match their PR titles.
+  It doesn't require you to be clairvoyant about knowing what the PR title will
+  be before you create the local branch: you can always rename the branch
+  before pushing with `git branch --move <new_name>`.
+
+Respond collaboratively to reviews
+----------------------------------
+
+Respond graciously to critiques:
+appreciate your reviewer's effort,
+see review notes as objective discussion and helpful lessons,
+be patient and polite,
+and try not to get defensive.
+Michael Lynch's [How to Make Your Code Reviewer Fall in Love with You](https://mtlynch.io/code-review-love/)
+has some great advice for this.

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -10,11 +10,9 @@ Make small PRs and atomic commits
 ---------------------------------
 
 A good guide is that each PR should do "one thing": a single logical change.
-Needing "and" in your PR title might be a sign that you should split it up. If
-you discover a bug while adding a new feature, send a separate PR to
-fix the bug. If code doesn't follow current conventions do a refactoring commit
-first then a separate commit to make your functional change. We like small PRs
-because:
+Needing "and" in your PR title might be a sign that you should split it up. 
+
+We like small PRs because:
 
 * They're necessary for [continuous deployment](merging.md): you can't deploy a small diff without first merging a small PR.
 * They get faster, better reviews: it takes less time and context-switching to review a small, focused PR.

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -3,8 +3,8 @@ Writing Commits and Pull Requests
 
 Small, atomic commits and pull requests (PRs) with helpful commit messages,
 PR titles and PR bodies are great for collaboration and key to a maintainable
-project. Tools like [`git rebase`](https://docs.github.com/en/get-started/using-git/using-git-rebase-on-the-command-line)
-can help you to rewrite commits and split up branches to tell a clean and coherent story.
+project. Tools like [`git rebase`](https://git-rebase.io/) can help you to
+rewrite commits and split up branches to tell a clean and coherent story.
 
 Make small PRs and atomic commits
 ---------------------------------

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -53,10 +53,10 @@ Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) because
 #### What should go in PR titles and bodies?
 
 For single-commit PRs GitHub pre-fills the title and body from the commit
-message. You might add some more details yourself: screenshots, testing
-instructions, review notes. Multi-commit PR titles can follow the same style as
-for single commits, the PR title and body can document the PR as a whole while
-commit messages can add detail to individual commits.
+message. You might add some more details to the PR body yourself: screenshots,
+testing instructions, review notes. Multi-commit PR titles can follow the same
+style as for single commits, the PR title and body can document the PR as a
+whole while commit messages can add detail to individual commits.
 
 [^1]: Using the imperative mood means writing your commit title as if giving
   the code a command to change itself, for example

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -35,7 +35,7 @@ write to explain your change to the whole team, not just the individual who'll r
 Enable future code archaeology: make it possible to understand and revisit your
 change months or years from now.
 
-#### What should go in commit and PR messages?
+#### What should go in commit messages?
 
 A commit's diff shows **how** the change was made: what lines of code were changed. 
 
@@ -49,6 +49,8 @@ The first line of a commit should summarize the intent in less than 50 chars
 because it works well with Git and GitHub which treat the first line as a title
 and use it throughout their interfaces.
 Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) because it's short and clear.[^1]
+
+#### What should go in PR titles and bodies?
 
 For single-commit PRs GitHub pre-fills the title and body from the commit
 message. You might add some more details yourself: screenshots, testing

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -37,10 +37,10 @@ change months or years from now.
 
 #### What should go in commit and PR messages?
 
-A commit's diff shows **how** the change was made: what lines of code were
-changed. It's up to the commit message to document **what you intended** the
-commit to achieve, **why** you're making this change, and any **context**
-or background knowledge necessary to understand the change.
+A commit's diff shows **how** the change was made: what lines of code were changed. 
+
+A commit's message needs to document the **intent** of the change, and provide any **context** necessary to understand the change.
+
 [My favourite Git commit](https://dhwthompson.com/2019/my-favourite-git-commit) (written by a former Hypothesis developer)
 and [Telling stories through your commits](https://blog.mocoso.co.uk/talks/2015/01/12/telling-stories-through-your-commits/)
 have some great tips.

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -20,10 +20,9 @@ because:
 * They get faster, better reviews: it takes less time and context-switching to review a small, focused PR.
 * They improve the quality of your work by encouraging clearly organized thinking, modular code, and purity of purpose.
 
-Make commits atomic: CI should be passing after each commit to enable tools
-like `git revert` and `git bisect` to be used effectively and to make history
-easier to browse and search by avoiding "fix", "typo" and "test" commits. Run
-`make sure` locally to make sure that CI will pass.
+Make commits atomic: CI should be passing after each commit to make tools like
+`git revert` and `git bisect` effective and history easier to navigate (no
+"fix", "typo" and "test" commits).
 
 <details><summary><b>When should you include more than one commit in a PR?</b></summary>
 If a few closely related commits would be easier to review and deploy together

--- a/docs/commits_and_prs.md
+++ b/docs/commits_and_prs.md
@@ -10,17 +10,17 @@ Make small PRs and atomic commits
 ---------------------------------
 
 A good guide is that each PR should do "one thing": a single logical change.
-Needing "and" in your PR title might be a sign that you should split it up. 
+An "and" in your PR title might be a sign that you should split it up.
 
 We like small PRs because:
 
-* They're necessary for [continuous deployment](merging.md): you can't deploy a small diff without first merging a small PR.
-* They get faster, better reviews: it takes less time and context-switching to review a small, focused PR.
-* They improve the quality of your work by encouraging clearly organized thinking, modular code, and purity of purpose.
+* They're necessary for [continuous deployment](merging.md): you can't deploy a small diff without first merging a small PR
+* They get faster, better reviews: it takes less time and context-switching to review a small, focused PR
+* They improve the quality of your work by encouraging clearly organized thinking, modular code, and purity of purpose
 
-Make commits atomic: CI should be passing after each commit to make tools like
-`git revert` and `git bisect` effective and history easier to navigate (no
-"fix", "typo" and "test" commits).
+Make commits atomic: CI should pass after each commit to make tools like `git
+revert` and `git bisect` effective and history easier to navigate (no "fix",
+"typo" and "test" commits).
 
 Write helpful commit messages, PR titles, and PR bodies
 -------------------------------------------------------
@@ -45,7 +45,7 @@ A commit's message needs to document the **intent** of the change, and provide a
 and [Telling stories through your commits](https://blog.mocoso.co.uk/talks/2015/01/12/telling-stories-through-your-commits/)
 have some great tips.
 
-The first line of a commit should summarize the intent in less than 50 chars
+The first line of a commit should summarize the intent in less than 50 characters
 because it works well with Git and GitHub which treat the first line as a title
 and use it throughout their interfaces.
 Use the [imperative mood](https://en.wikipedia.org/wiki/Imperative_mood) because it's short and clear.[^1]


### PR DESCRIPTION
Add a guide to what we consider to be good commit and PR practices at Hypothesis: small, atomic commits and PRs with great commit messages, PR titles, and PR bodies.

[HTML preview](https://github.com/hypothesis/onboarding/blob/add-commit-and-pr-guidelines/docs/commits_and_prs.md).

Fixes https://github.com/hypothesis/onboarding/issues/46.

This replaces two SO4T posts [How do I write a good commit message?](https://stackoverflow.com/c/hypothesis/questions/392) and [How do I write a good pull request?](https://stackoverflow.com/c/hypothesis/questions/385) which will be replaced with links to this post.

This is referenced by the [issue template for doing your first PR](https://github.com/hypothesis/onboarding/blob/main/.github/ISSUE_TEMPLATE/04_first_pr.md) (this PR updates the link to point to the new document).

Why do we need this? We're very particular about what kinds of commits and PRs we want, and for good reason. I don't think our approach is unique to Hypothesis, it used to be more controversial but now it's becoming a more and more popular and well-known approach. Nonetheless we can (and often have) hired people who aren't familiar with this approach or who may have even heard that things like rewriting history and carefully crafting commit messages are bad and a misguided waste of time. As part of our onboarding we do need to explain to people what kind of commits and PRs we want and why this approach is a good idea.

This is a very complex and interconnected topic, there's so much you could say about this and it's very hard to boil it down to a really concise and well-organized document that communicates the essentials. This first-pass at least meets my self-imposed "fits on one screen" (on my screen) maximum length constraint, although I've cheated slightly by using one `<details>` element and a couple of footnotes. If it can be made more concise and expressive that would certainly be an improvement.

The posts that the document links to ([Every line of code is always documented](https://mislav.net/2014/02/hidden-documentation/), [My favourite Git commit](https://dhwthompson.com/2019/my-favourite-git-commit), [Telling stories through your commits](https://blog.mocoso.co.uk/talks/2015/01/12/telling-stories-through-your-commits/) and [How to Make Your Code Reviewer Fall in Love with You](https://mtlynch.io/code-review-love/)) aren't chosen lightly: they're well worth reading, the really standout examples that I've found among the many mediocre posts on this topic.