### PR TITLE
Add introductory text

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_introduction.md
+++ b/.github/ISSUE_TEMPLATE/02_introduction.md
@@ -7,6 +7,22 @@ assignees: ''
 
 ---
 
+Welcome to your Hypothesis engineer onboarding! Here's what to expect:
+
+* Your manager @MANAGERS_GITHUB_USERNAME and buddy @BUDDYS_GITHUB_USERNAME will help you through each phase of the onboarding process.
+* We'll use GitHub issues like this one to keep track of each phase of your onboarding. You can use the comments on the bottom of each issue to discuss things with your manager and buddy.
+* We'll use [your onboarding project board](PROJECT_BOARD_URL) to keep track of all your onboarding issues as you progress through them.
+* Your onboarding tasks will cover things like:
+  * Reading important documents like our code of conduct and engineering values
+  * Learning the high-level organization of our product, codebase, architecture and processes
+  * Setting up your local development environment
+  * Sending your first pull requests
+  * Doing your first code reviews
+  * Joining our on-call schedule
+  * Participating in your first real project from start to finish
+
+## Introductory tasks
+
 - [ ] **Manager**: **schedule a product walkthrough** for the engineer with someone from product or support
   - [ ] **Engineer**: check off this item once you've had the product walkthrough
 - [ ] **Manager**: **assign a buddy** for the engineer's onboarding


### PR DESCRIPTION
[HTML preview](https://github.com/hypothesis/onboarding/blob/add-introductory-text/.github/ISSUE_TEMPLATE/02_introduction.md).

Add an introductory paragraph to the "Introduction" issue template (which is the template for the first issue to be assigned to a new engineer on their onboarding board).

The aim of this introductory paragraph is to welcome the engineer and introduce them to the onboarding process, how it works, and what they can expect from it.

I deliberately haven't mentioned a timeline or how long onboarding might take because I think that will vary from one engineer to the next.

Fixes https://github.com/hypothesis/onboarding/issues/33
