### PR TITLE
Fix paths to architecture images

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,19 +2,19 @@
 
 ## Embedded client
 
-![Embedded client architecture diagram](docs/images/arch-embedded-client.png)
+![Embedded client architecture diagram](/docs/images/arch-embedded-client.png)
 
 ## Proxied website
 
-![Proxied website architecture diagram](docs/images/arch-proxied-website.png)
+![Proxied website architecture diagram](/docs/images/arch-proxied-website.png)
 
 ## Proxied PDF
 
-![Proxied website architecture diagram](docs/images/arch-proxied-pdf.png)
+![Proxied website architecture diagram](/docs/images/arch-proxied-pdf.png)
 
 ## LMS PDF
 
-![Proxied website architecture diagram](docs/images/arch-lms-pdf.png)
+![Proxied website architecture diagram](/docs/images/arch-lms-pdf.png)
 
 ## Legacy
 


### PR DESCRIPTION
Fix typos introduced in https://github.com/hypothesis/onboarding/pull/95, where paths to architecture diagrams where missing the leading slash before `docs`, causing the routes to expand to a double `docs/docs/...` segment.